### PR TITLE
Add cld2-sys/prepackage.sh which cuts cld2 to fit within 10MB.

### DIFF
--- a/cld2-sys/prepackage.sh
+++ b/cld2-sys/prepackage.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+cd cld2
+git checkout .
+rm -rf docs/
+for i in internal/cld_generated_*.cc internal/cld2_generated_*.cc; do
+	# NOTE: make sure that this whitelist reflects the file list in src/build.rs!
+	case $i in
+	*/cld_generated_cjk_uni_prop_80.cc|\
+	*/cld2_generated_cjk_compatible.cc|\
+	*/cld_generated_cjk_delta_bi_32.cc|\
+	*/cld2_generated_quad0122.cc|\
+	*/cld2_generated_deltaocta0122.cc|\
+	*/cld2_generated_distinctocta0122.cc|\
+	*/cld_generated_score_quad_octa_0122.cc)
+		echo $i: processed
+		sed -i 's/^\([ \t]*{*\(0x[0-9a-fA-F]\+,[ \t]*\)\{3\}0x[0-9a-fA-F]\+}*,\)[ \t]*\/\/.*$/\1/' $i
+		;;
+	*)
+		echo $i: removed
+		rm -f $i
+		;;
+	esac
+done

--- a/cld2-sys/src/build.rs
+++ b/cld2-sys/src/build.rs
@@ -2,6 +2,7 @@ extern crate gcc;
 
 use std::default::Default;
 
+// NOTE: make sure that the whitelist in prepackage.sh reflects this file list!
 static CLD2_FULL_SOURCES: &'static [&'static str] = &[
     "cldutil.cc", "cldutil_shared.cc", "compact_lang_det.cc",
     "compact_lang_det_hint_code.cc", "compact_lang_det_impl.cc", "debug.cc",


### PR DESCRIPTION
This commit should cut `cld2-sys-*.crate` down to about 6MB. You have to call `./prepackage.sh` every time `cld2-sys` gets updated, but well, at least we can work around rust-lang/crates.io#40.

Observations: First, apparently we are not using all available tables (e.g. `cld2_generated_quad0720.cc`, one of the largest unused file). Second, most tables have informational comments interspersed with actual data, which is very bad at its own _and_ for the compression (lots of excess information entropy to affect the coding scheme, missed opportunities due to the effectively narrowed window size, etc.). `prepackage.sh` should eliminate both.

Future direction: I've also tested a simple packer and unpacker that will turn the textual tables into the binary form (while removing comments). This does _not_ fit in 10MB but still is promising, the best I can get was about 13MB. This does have an advantage of not removing any tables. If you are interested in this (and if crates.io abandons the strict size limit :) I can write the robust code to do this.
