### PR TITLE
Remove errors when building cld2 with gcc -std=c++11

### DIFF
--- a/cld2-sys/build.rs
+++ b/cld2-sys/build.rs
@@ -55,7 +55,11 @@ fn main() {
     // Run the build.
     let mut config = gcc::Config::new();
     config.cpp(true);
-    config.flag("-Wno-error=narrowing");
+    let cxxflags = match env::var("CXXFLAGS") {
+        Ok(val) => val + " -std=c++03",
+        Err(..) => String::from("-std=c++03"),
+    };
+    env::set_var("CXXFLAGS", &cxxflags);
     config.include(&Path::new("cld2/public"));
     config.include(&Path::new("cld2/internal"));
     for f in sources.iter() {

--- a/cld2-sys/build.rs
+++ b/cld2-sys/build.rs
@@ -55,6 +55,7 @@ fn main() {
     // Run the build.
     let mut config = gcc::Config::new();
     config.cpp(true);
+    config.flag("-Wno-error=narrowing");
     config.include(&Path::new("cld2/public"));
     config.include(&Path::new("cld2/internal"));
     for f in sources.iter() {


### PR DESCRIPTION
Apparently, narrowing conversions are disallowed in C++11. This line
turns the errors that pop up when compiling cld2 with a C++11-adhering
GCC into warnings.

I dedicate any and all copyright interest in my contributions to this
project to the public domain. I make this dedication for the benefit of
the public at large and to the detriment of my heirs and successors. I
intend this dedication to be an overt act of relinquishment in
perpetuity of all present and future rights to this software under
copyright law.