### PR TITLE
cld2-sys: exclude compiled object files explicitly

### DIFF
--- a/cld2-sys/Cargo.toml
+++ b/cld2-sys/Cargo.toml
@@ -16,7 +16,8 @@ repository = "https://github.com/emk/rust-cld2"
 # 10MB Rust package.  We start upstream, by remove a large unit-test data
 # file and stripping line comments out of the generated files.  Then we
 # strip out the docs directory, our own table-stripping script, plus a list
-# of source files that we're not actually building.
+# of source files that we're not actually building. Last, we strip out all
+# compiled code (*_chrome_* and *.o files).
 #
 # The command used to generate the list of unused *.cc files below looked
 # something like this:
@@ -28,7 +29,10 @@ repository = "https://github.com/emk/rust-cld2"
 # list using a toml parser, compare it against the source directly, and
 # generate a list of files to compile.
 exclude = [
-  "cld2/docs",
+  "*.o",
+  "*_chrome_*",
+
+  "cld2/docs/**",
   "cld2/strip_tables.sh",
 
   "cld2/internal/cld2_do_score.cc",


### PR DESCRIPTION
If you cd into the cld2 directory and compile object files,
you will create object artifacts next to the source code.
Cargo package will automatically include them.

Also, contents of the docs directory did not get excluded.

Fixes issue #4.